### PR TITLE
jwt認証機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,13 @@
         "@prisma/client": "^5.2.0",
         "bcrypt": "^5.1.1",
         "express": "^4.18.2",
+        "jsonwebtoken": "^9.0.2",
         "nodemon": "^3.0.1"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.0",
         "@types/express": "^4.17.17",
+        "@types/jsonwebtoken": "^9.0.3",
         "@types/node": "^20.6.0",
         "prisma": "^5.2.0",
         "typescript": "^5.2.2"
@@ -144,6 +146,15 @@
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==",
       "dev": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-b0jGiOgHtZ2jqdPgPnP6WLCXZk1T8p06A/vPGzUvxpFGgKMbjXJDjC5m52ErqBnIuWZFgGoIJyRdeG5AyreJjA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -350,6 +361,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -490,6 +506,14 @@
       "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -893,6 +917,86 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",
     "@types/express": "^4.17.17",
+    "@types/jsonwebtoken": "^9.0.3",
     "@types/node": "^20.6.0",
     "prisma": "^5.2.0",
     "typescript": "^5.2.2"
@@ -19,6 +20,7 @@
     "@prisma/client": "^5.2.0",
     "bcrypt": "^5.1.1",
     "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2",
     "nodemon": "^3.0.1"
   }
 }

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -1,0 +1,54 @@
+import express, { RequestHandler} from 'express';
+import { PrismaClient, Politician, Board } from "@prisma/client";
+import bcrypt from 'bcrypt'
+import jwt from 'jsonwebtoken'
+import { UserAuthenticatedRequest } from 'types/request';
+
+
+const prisma = new PrismaClient();
+
+type LoginArgs = {
+    name: string,
+    password: string
+}
+
+const isLoginArgs = (value: unknown): value is LoginArgs => {
+    const v = value as LoginArgs
+
+    return (
+        typeof v?.name === 'string' &&
+        typeof v?.password === 'string'
+    )
+}
+
+export const login: RequestHandler = async (req, res, next) => {
+    if (!isLoginArgs(req.body)) {
+        res.json({ error: 'invalid args'})
+        return
+    }
+
+    const user = await prisma.user.findUnique({
+        where: {
+            name: req.body.name
+        }
+    })
+
+    if (user === null) {
+        res.json({ error: 'user is not exists'})
+        return
+    }
+
+    if (!bcrypt.compareSync(req.body.password, user.hashedPassword)) {
+        res.json({ error: 'password is incorrect'})
+    }
+
+    // JWT生成
+    const jwtSecret: string = typeof process.env.JWT_SECRET === 'string' ? process.env.JWT_SECRET : "VeryStrongPassword"
+
+    const token = jwt.sign({user: { id: user.id}}, jwtSecret, {
+        algorithm: 'HS256',
+        expiresIn: '1h'
+    });
+    
+    res.json({ token })
+}

--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -1,6 +1,7 @@
 import express, { RequestHandler} from 'express';
 import { PrismaClient, User } from '@prisma/client'
 import bcrypt from 'bcrypt'
+import { UserAuthenticatedRequest } from 'types/request';
 
 const prisma = new PrismaClient();
 
@@ -52,4 +53,14 @@ export const registerUser: RequestHandler = async (req, res, next) => {
     })
 
     res.json({ user: makeUserResponse(user) })
+}
+
+export const getUser: RequestHandler = async (req, res, next) => {
+    const ureq = req as UserAuthenticatedRequest
+
+    if (typeof ureq.user === 'undefined') {
+        throw Error('not authenticated')
+    }
+
+    res.json({ user: makeUserResponse(ureq.user)})
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,13 @@
 import express, { Request, Response, NextFunction} from 'express';
 import userRoutes  from "./routes/users";
 import politicianRoutes  from "./routes/politicians";
+import auth from "./routes/auth"
 
 
 const app = express();
 app.use(express.json());
 
+app.use("/auth", auth);
 app.use("/users", userRoutes);
 app.use("/politicians", politicianRoutes);
 

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,0 +1,61 @@
+import { PrismaClient } from "@prisma/client";
+import { RequestHandler } from "express";
+import jwt from 'jsonwebtoken'
+import { UserAuthenticatedRequest } from "types/request";
+
+const prisma = new PrismaClient()
+
+type UserClaim = {
+    user: {
+        id: number
+    }
+}
+
+const isUserClaim = (value: unknown): value is UserClaim => {
+    const v = value as UserClaim
+
+    return (
+        typeof v?.user?.id === 'number'
+    )
+}
+
+export const authenticateUser: RequestHandler = async (req, res, next) => {
+    if (typeof req.headers.authorization === "undefined") {
+        res.send('authentication error')
+        return
+    }
+
+    // `Bearer `を除外
+    const token = req.headers.authorization.substring(7)
+
+    const jwtSecret: string = typeof process.env.JWT_SECRET === 'string' ? process.env.JWT_SECRET : "VeryStrongPassword"
+
+    let claim: string | jwt.JwtPayload
+    try {
+        claim = jwt.verify(token, jwtSecret)
+    } catch (error) {
+        res.send(error)
+        return
+    }
+
+    if (!isUserClaim(claim)) {
+        res.send('authentication error')
+        return
+    }
+
+    const user = await prisma.user.findUnique({
+        where: {
+            id: claim.user.id
+        }
+    })
+    if (user === null) {
+        res.send('authentication error')
+        return
+    }
+
+    const ureq = req as UserAuthenticatedRequest
+
+    ureq.user = user
+
+    next()
+}

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { login } from "../controllers/auth"
+
+const router = Router();
+
+router.post("/login", login);
+
+export default router

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,16 +1,16 @@
 import { Router } from "express";
-import { getAllUsers, registerUser } from "../controllers/users";
+import { getAllUsers, registerUser, getUser } from "../controllers/users";
+import { authenticateUser } from "../middlewares/auth";
 
 
 
 const router = Router();
 
 
+router.get("/", authenticateUser, getUser)
 
-router.get("/", getAllUsers);
+router.get("/all", getAllUsers);
 
 router.post("/register", registerUser);
-
-//router.post("/login", loginUser);
 
 export default router

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -1,0 +1,6 @@
+import { User } from '@prisma/client'
+import { Request } from 'express'
+
+export type UserAuthenticatedRequest = Request & {
+    user?: User
+}


### PR DESCRIPTION
Close #6 

## 概要
- `POST /auth/login`のエンドポイントでユーザー認証を行い、トークンを発行できるようにしました
- ユーザー認証用のミドルウェア`authenticateUser`を実装しました
- `GET /user/`で、全ユーザーの取得から、ログイン中のユーザー情報の取得に仕様変更しました
- `GET /user/all`で全ユーザー情報を取得できるようにしました
ただし、セキュリティ的に良くないので将来的に取得できる情報の絞り込みの必要あり

## 詳細
以降、ユーザー認証が必要なエンドポイントでは、ルーティング部で以下のようにauthenticateUserを挟むことで、req.userからログイン中のユーザー情報を取得できます。
```
import { authenticateUser } from 'middlewares/auth'

router.get('/', authenticateUser, controller)
```

ただし、コントローラー部ではreqをUserAuthenticatedRequest型に強制キャストする必要があります。
```
import { UserAuthenticatedRequest } from 'types/request'

const ureq = req as UserAuthenticatedRequest
```

